### PR TITLE
Allow early loading of VoodooGPIO

### DIFF
--- a/VoodooGPIO/Info.plist
+++ b/VoodooGPIO/Info.plist
@@ -48,32 +48,32 @@
 			<key>IOProviderClass</key>
 			<string>IOService</string>
 		</dict>
-        <key>VoodooGPIOCannonLakeLP</key>
-        <dict>
-            <key>CFBundleIdentifier</key>
-            <string>org.coolstar.VoodooGPIO</string>
-            <key>IOClass</key>
-            <string>VoodooGPIOCannonLakeLP</string>
-            <key>IONameMatch</key>
-            <array>
-                <string>INT34BB</string>
-            </array>
-            <key>IOProviderClass</key>
-            <string>IOService</string>
-        </dict>
-        <key>VoodooGPIOCannonLakeH</key>
-        <dict>
-            <key>CFBundleIdentifier</key>
-            <string>org.coolstar.VoodooGPIO</string>
-            <key>IOClass</key>
-            <string>VoodooGPIOCannonLakeH</string>
-            <key>IONameMatch</key>
-            <array>
-                <string>INT3450</string>
-            </array>
-            <key>IOProviderClass</key>
-            <string>IOService</string>
-        </dict>
+		<key>VoodooGPIOCannonLakeLP</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>org.coolstar.VoodooGPIO</string>
+			<key>IOClass</key>
+			<string>VoodooGPIOCannonLakeLP</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>INT34BB</string>
+			</array>
+			<key>IOProviderClass</key>
+			<string>IOService</string>
+		</dict>
+		<key>VoodooGPIOCannonLakeH</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>org.coolstar.VoodooGPIO</string>
+			<key>IOClass</key>
+			<string>VoodooGPIOCannonLakeH</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>INT3450</string>
+			</array>
+			<key>IOProviderClass</key>
+			<string>IOService</string>
+		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 CoolStar. All rights reserved.</string>
@@ -88,5 +88,7 @@
 		<key>com.apple.kpi.mach</key>
 		<string>13.0</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
 </dict>
 </plist>


### PR DESCRIPTION
This change allows VoodooGPIO to load much earlier, and is necessary due to https://github.com/alexandred/VoodooI2C/commit/c6e3c278cda84a26f400a77f5ea57d819df9e405. The GPIO controller won't load early enough without kOSBundleRequiredRoot and VoodooI2CDeviceNub won't find it.

(Info.plist reformatted by Xcode to use tabs)