### PR TITLE
Fixes cursor movement lagging or jumping since 2.1.4+

### DIFF
--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -546,8 +546,6 @@ bool VoodooGPIO::start(IOService *provider) {
     
     isInterruptBusy = true;
     
-    PMinit();
-    
     workLoop = getWorkLoop();
     if (!workLoop) {
         IOLog("%s::Failed to get workloop!\n", getName());
@@ -656,6 +654,7 @@ bool VoodooGPIO::start(IOService *provider) {
     myPowerStates[1].outputPowerCharacter = kIOPMPowerOn;
     myPowerStates[1].inputPowerRequirement = kIOPMPowerOn;
     
+    PMinit();
     provider->joinPMtree(this);
     
     registerPowerDriver(this, myPowerStates, kMyNumberOfStates);
@@ -698,7 +697,7 @@ void VoodooGPIO::stop(IOService *provider) {
     }
     
     if (workLoop) {
-        // workLoop->release();
+        workLoop->release();
         workLoop = NULL;
     }
     

--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -85,26 +85,6 @@ void VoodooGPIO::writel(UInt32 b, IOVirtualAddress addr) {
     *(volatile UInt32 *)(addr) = b;
 }
 
-IOWorkLoop* VoodooGPIO::getWorkLoop() {
-    // Do we have a work loop already?, if so return it NOW.
-    if ((vm_address_t) workLoop >> 1)
-        return workLoop;
-
-    if (OSCompareAndSwap(0, 1, reinterpret_cast<IOWorkLoop*>(&workLoop))) {
-        // Construct the workloop and set the cntrlSync variable
-        // to whatever the result is and return
-        workLoop = IOWorkLoop::workLoop();
-    } else {
-        while (reinterpret_cast<IOWorkLoop*>(workLoop) == reinterpret_cast<IOWorkLoop*>(1)) {
-            // Spin around the cntrlSync variable until the
-            // initialization finishes.
-            thread_block(0);
-        }
-    }
-
-    return workLoop;
-}
-
 struct intel_community *VoodooGPIO::intel_get_community(unsigned pin) {
     struct intel_community *community;
     for (int i = 0; i < ncommunities; i++) {

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -197,8 +197,9 @@ class VoodooGPIO : public IOService {
     bool controllerIsAwake;
 
     IOWorkLoop *workLoop;
-    IOInterruptEventSource *interruptSource;
-    IOCommandGate* command_gate;
+    IOInterruptEventSource *interruptSource = NULL;
+    IOCommandGate* command_gate = NULL;
+    bool isInterruptBusy;
 
     UInt32 readl(IOVirtualAddress addr);
     void writel(UInt32 b, IOVirtualAddress addr);

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -120,6 +120,7 @@ struct intel_community {
     const struct intel_padgroup *gpps;
     size_t ngpps;
     bool gpps_alloc;
+    bool *isActiveCommunity;
     /* Reserved for the core driver */
     IOMemoryMap *mmap;
     IOVirtualAddress regs;
@@ -197,9 +198,10 @@ class VoodooGPIO : public IOService {
     bool controllerIsAwake;
 
     IOWorkLoop *workLoop;
-    IOInterruptEventSource *interruptSource = NULL;
-    IOCommandGate* command_gate = NULL;
+    IOInterruptEventSource *interruptSource;
+    IOCommandGate* command_gate;
     bool isInterruptBusy;
+    UInt32 nInactiveCommunities;
 
     UInt32 readl(IOVirtualAddress addr);
     void writel(UInt32 b, IOVirtualAddress addr);
@@ -228,7 +230,7 @@ class VoodooGPIO : public IOService {
     void intel_gpio_irq_init();
     void intel_pinctrl_resume();
 
-    void intel_gpio_community_irq_handler(struct intel_community *community);
+    void intel_gpio_community_irq_handler(struct intel_community *community, bool *firstdelay);
 
     void InterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount);
     void interruptOccurredGated();

--- a/VoodooGPIO/VoodooGPIO.hpp
+++ b/VoodooGPIO/VoodooGPIO.hpp
@@ -203,8 +203,6 @@ class VoodooGPIO : public IOService {
     UInt32 readl(IOVirtualAddress addr);
     void writel(UInt32 b, IOVirtualAddress addr);
 
-    IOWorkLoop* getWorkLoop();
-
     struct intel_community *intel_get_community(unsigned pin);
     const struct intel_padgroup *intel_community_get_padgroup(const struct intel_community *community, unsigned pin);
     IOVirtualAddress intel_get_padcfg(unsigned pin, unsigned reg);


### PR DESCRIPTION
getWorkLoop in VoodooGPIO are causing lagging/jumping. Removing the method solves in both VoodooGPIO.cpp and VoodooI2CControllerDriver.cpp, solved the issues.