### PR TITLE
Fix building with the macOS 10.15 SDK

### DIFF
--- a/VoodooGPIO/VoodooGPIO.cpp
+++ b/VoodooGPIO/VoodooGPIO.cpp
@@ -135,13 +135,13 @@ IOVirtualAddress VoodooGPIO::intel_get_padcfg(unsigned pin, unsigned reg) {
     
     community = intel_get_community(pin);
     if (!community)
-        return NULL;
+        return 0;
     
     padno = pin_to_padno(community, pin);
     nregs = (community->features & PINCTRL_FEATURE_DEBOUNCE) ? 4 : 2;
     
     if (reg == PADCFG2 && !(community->features & PINCTRL_FEATURE_DEBOUNCE))
-        return NULL;
+        return 0;
     
     return community->pad_regs + reg + padno * nregs * 4;
 }


### PR DESCRIPTION
`NULL` is now defined as `nullptr` instead of `0`, when using C++11 or newer.
As it was used as an `IOVirtualAddress` in some places, build fails when using the newer SDK.

From IOTypes.h:
```
#if __cplusplus >= 201103L
#define NULL nullptr
#else
#define NULL    0
#endif